### PR TITLE
some suggested improvements

### DIFF
--- a/addons/toggle_external_editor/toggle_external_editor_dock.gd
+++ b/addons/toggle_external_editor/toggle_external_editor_dock.gd
@@ -4,11 +4,11 @@ extends Control
 const USE_EXTERNAL_EDITOR_SETTING_STRING: String = "text_editor/external/use_external_editor"
 
 var settings = EditorInterface.get_editor_settings()
-var is_enable_external_editor := settings.get(USE_EXTERNAL_EDITOR_SETTING_STRING)
 @onready var check_box: CheckBox = $HBoxContainer/CheckBox
 
 func _ready() -> void:
-	check_box.button_pressed = is_enable_external_editor
+	check_box.set_pressed_no_signal(settings.get(USE_EXTERNAL_EDITOR_SETTING_STRING))
+	settings.settings_changed.connect(_on_settings_changed)
 	
 
 func _on_link_button_pressed() -> void:
@@ -21,3 +21,7 @@ func _on_check_box_toggled(toggled_on: bool) -> void:
 	else:
 		print('Plugin<toggle_external_editor>: disable external editor')
 		settings.set(USE_EXTERNAL_EDITOR_SETTING_STRING, false)
+
+
+func _on_settings_changed() -> void:
+	check_box.set_pressed_no_signal(settings.get(USE_EXTERNAL_EDITOR_SETTING_STRING))


### PR DESCRIPTION
This PR:

- uses `check_box.set_pressed_no_signal` when setting the value of the `check_box` when we do not want to trigger a signal (instead of `button_pressed` which triggers a signal)
- adds `settings.settings_changed.connect(_on_settings_changed)` so that any changes made in Godot's UI to set this checkbox reflects in the extension's checkbox (keeps them in sync).